### PR TITLE
Remove rage.lol

### DIFF
--- a/data/ignorehosts.yml
+++ b/data/ignorehosts.yml
@@ -364,3 +364,4 @@
 - miss.nem.one
 - mlsskey.io
 - www.memesskey.com
+- rage.lol

--- a/data/instances.yml
+++ b/data/instances.yml
@@ -552,8 +552,6 @@
   langs: ['en']
 - url: social.ahlo.club
   langs: ['en']
-- url: rage.lol
-  langs: ['en']
 - url: mk.voring.me
   langs: ['en']
 - url: yuustan.space


### PR DESCRIPTION
@tamaina rage.lol has been added to Fediblock, and for a long time they've been known for being a bad instance with racist and bigoted views. I don't think they should be promoted because so many people block them (for a good reason).
