### PR TITLE
Remove fbk.moe from ignorehosts.yml

### DIFF
--- a/data/ignorehosts.yml
+++ b/data/ignorehosts.yml
@@ -542,7 +542,6 @@
 - beg.plead.help
 - moe.foxarmy.ml
 - silkhe.art
-- fbk.moe
 - mss.cgnat.net
 - ente.fun
 - catgirl.misskey.lol

--- a/data/instances.yml
+++ b/data/instances.yml
@@ -1595,6 +1595,8 @@
   langs: ['zh']
 - url: catcore.life
   langs: ['zh']
+- url: fbk.moe
+  langs: ['zh']
 ##
 #########################################
 ##


### PR DESCRIPTION
It looks like this domain is added to ignorehosts before. But now it is the domain of my personal Misskey instance.

Could you help me remove it from the ignore list and add it to the instance list?