### PR TITLE
Remove `balloon.potp.me` and add `ebi.bal.ovh`

### DIFF
--- a/data/instances.yml
+++ b/data/instances.yml
@@ -365,8 +365,6 @@
   langs: ['ja']
 - url: mi.tebukuro.xyz
   langs: ['ja']
-- url: balloon.potp.me
-  langs: ['ja']
 - url: porubuskey.cc
   langs: ['ja']
 - url: pillbug.audio.amanogawa.work
@@ -1166,6 +1164,8 @@
 - url: houshindai.net
   langs: ['ja']
 - url: cosmisskey.cc
+  langs: ['ja']
+- url: ebi.bal.ovh
   langs: ['ja']
 #
 ##


### PR DESCRIPTION
`balloon.potp.me` is already closed.
Add a new Misskey (Ebisskey) server `ebi.bal.ovh` instead.