### PR TITLE
Add social.sda1.net and ne.bal.ovh

### DIFF
--- a/data/instances.yml
+++ b/data/instances.yml
@@ -1731,6 +1731,10 @@
   langs: ['ja']
 - url: pickey.net
   langs: ['ja']
+- url: social.sda1.net
+  langs: ['ja']
+- url: ne.bal.ovh
+  langs: ['ja']
 #
 ##
 #########################################


### PR DESCRIPTION
Misskey v12 派生の Nexkey を採用している mi.nexryai.online が登録されて一覧に表示されているので（API などは Misskey v12 で返します）同じ Nexkey を採用していて、公開状態にしてある次のサーバーを登録して下さい。

・social.sda1.net (mi.nexryai.online と同じ nexryai さん運営) ・ne.bal.ovh (ふうせん🎈 FU-SEN 運営)

よろしくお願いいたします。