### PR TITLE
Update instances.yml

### DIFF
--- a/data/instances.yml
+++ b/data/instances.yml
@@ -1698,8 +1698,6 @@
   langs: ['zh']
 - url: zmi.im
   langs: ['zh']
-- url: pastwind.top
-  langs: ['zh']
 - url: existentialis.me
   langs: ['zh']
 - url: pari.cafe
@@ -1759,6 +1757,8 @@
 - url: flojoy.fun
   langs: ['zh']
 - url: urweibo.com
+  langs: ['zh']
+- url: mistyreverie.org
   langs: ['zh']
 #ko
 - url: madost.one


### PR DESCRIPTION
add mistyreverie.org
remove pastwind.top

pastwind.top will be shutting down and migrating to the new site mistyreverie.org.