### PR TITLE
Remove Mezanine (``misskey.repn.my.id``) from instance list

### DIFF
--- a/data/instances.yml
+++ b/data/instances.yml
@@ -1628,8 +1628,6 @@
   langs: ['en', 'ja', 'sk', 'de']
 - url: byzantinenexus.io
   langs: ['en']
-- url: misskey.repn.my.id
-  langs: ['en', 'ja', 'id']
 - url: kawaii.party
   langs: ['en']
 #it


### PR DESCRIPTION
Due to unforeseen circumstances, we unfortunately have to decommission our Misskey instance. This pr is to remove the instance from the Misskey Hub server list.